### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Automatic Swift network activity logger for iOS or OSX.
 
-![Cocoapods](https://img.shields.io/cocoapods/v/Timberjack.svg?style=plain) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) ![MIT](https://img.shields.io/cocoapods/l/Timberjack.svg?style=flat) ![iOS](https://img.shields.io/cocoapods/p/Timberjack.svg?style=flat)
+![CocoaPods](https://img.shields.io/cocoapods/v/Timberjack.svg?style=plain) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) ![MIT](https://img.shields.io/cocoapods/l/Timberjack.svg?style=flat) ![iOS](https://img.shields.io/cocoapods/p/Timberjack.svg?style=flat)
 
 Timberjack is a simple, unintrusive network activity logger. Log every request your app makes, or limit to only those using a certain `NSURLSession` if you'd prefer. It also works with [Alamofire](https://github.com/Alamofire/Alamofire), if that's your thing.
 
@@ -20,7 +20,7 @@ Timberjack is a simple, unintrusive network activity logger. Log every request y
 
 Timberjack is installed as an embedded framework, and such requires at least iOS8. If you require iOS7 compatibility, simply drag the `Timberjack.swift` file into your own project.
 
-###Cocoapods
+###CocoaPods
 
 Add the following to your Podfile
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
