### PR TITLE
Reset ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES flags.

### DIFF
--- a/Example/Timberjack Example.xcodeproj/project.pbxproj
+++ b/Example/Timberjack Example.xcodeproj/project.pbxproj
@@ -7,15 +7,55 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3CF8B81D1E7B907400FD70DE /* Timberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CF8B81A1E7B905E00FD70DE /* Timberjack.framework */; };
+		3CF8B81E1E7B907400FD70DE /* Timberjack.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3CF8B81A1E7B905E00FD70DE /* Timberjack.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A1825E5D1B99BCA5001C4857 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1825E5C1B99BCA5001C4857 /* AppDelegate.swift */; };
 		A1825E5F1B99BCA5001C4857 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1825E5E1B99BCA5001C4857 /* ViewController.swift */; };
 		A1825E621B99BCA5001C4857 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A1825E601B99BCA5001C4857 /* Main.storyboard */; };
 		A1825E641B99BCA5001C4857 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1825E631B99BCA5001C4857 /* Assets.xcassets */; };
 		A1825E671B99BCA5001C4857 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A1825E651B99BCA5001C4857 /* LaunchScreen.storyboard */; };
-		A1825E7D1B99C88B001C4857 /* Timberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1825E7C1B99C88B001C4857 /* Timberjack.framework */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		3CF8B8191E7B905E00FD70DE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3CF8B8141E7B905E00FD70DE /* Timberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A1D2658E1B9999E3000D8735;
+			remoteInfo = Timberjack;
+		};
+		3CF8B81B1E7B905E00FD70DE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3CF8B8141E7B905E00FD70DE /* Timberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A1D265991B9999E3000D8735;
+			remoteInfo = TimberjackTests;
+		};
+		3CF8B81F1E7B907400FD70DE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3CF8B8141E7B905E00FD70DE /* Timberjack.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = A1D2658D1B9999E3000D8735;
+			remoteInfo = Timberjack;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		3CF8B8211E7B907400FD70DE /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				3CF8B81E1E7B907400FD70DE /* Timberjack.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		3CF8B8141E7B905E00FD70DE /* Timberjack.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Timberjack.xcodeproj; path = ../../Timberjack.xcodeproj; sourceTree = "<group>"; };
 		A1825E591B99BCA5001C4857 /* Timberjack Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Timberjack Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1825E5C1B99BCA5001C4857 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A1825E5E1B99BCA5001C4857 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -23,7 +63,6 @@
 		A1825E631B99BCA5001C4857 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A1825E661B99BCA5001C4857 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		A1825E681B99BCA5001C4857 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		A1825E7C1B99C88B001C4857 /* Timberjack.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Timberjack.framework; path = "../build/Debug-iphoneos/Timberjack.framework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -31,13 +70,22 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A1825E7D1B99C88B001C4857 /* Timberjack.framework in Frameworks */,
+				3CF8B81D1E7B907400FD70DE /* Timberjack.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3CF8B8151E7B905E00FD70DE /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3CF8B81A1E7B905E00FD70DE /* Timberjack.framework */,
+				3CF8B81C1E7B905E00FD70DE /* TimberjackTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		A1825E501B99BCA5001C4857 = {
 			isa = PBXGroup;
 			children = (
@@ -58,6 +106,7 @@
 		A1825E5B1B99BCA5001C4857 /* Timberjack Example */ = {
 			isa = PBXGroup;
 			children = (
+				3CF8B8141E7B905E00FD70DE /* Timberjack.xcodeproj */,
 				A1825E5C1B99BCA5001C4857 /* AppDelegate.swift */,
 				A1825E5E1B99BCA5001C4857 /* ViewController.swift */,
 				A1825E601B99BCA5001C4857 /* Main.storyboard */,
@@ -71,7 +120,6 @@
 		A1825E7E1B99C8E5001C4857 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				A1825E7C1B99C88B001C4857 /* Timberjack.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -86,10 +134,12 @@
 				A1825E551B99BCA5001C4857 /* Sources */,
 				A1825E561B99BCA5001C4857 /* Frameworks */,
 				A1825E571B99BCA5001C4857 /* Resources */,
+				3CF8B8211E7B907400FD70DE /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				3CF8B8201E7B907400FD70DE /* PBXTargetDependency */,
 			);
 			name = "Timberjack Example";
 			productName = "Timberjack Example";
@@ -121,12 +171,35 @@
 			mainGroup = A1825E501B99BCA5001C4857;
 			productRefGroup = A1825E5A1B99BCA5001C4857 /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 3CF8B8151E7B905E00FD70DE /* Products */;
+					ProjectRef = 3CF8B8141E7B905E00FD70DE /* Timberjack.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				A1825E581B99BCA5001C4857 /* Timberjack Example */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		3CF8B81A1E7B905E00FD70DE /* Timberjack.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Timberjack.framework;
+			remoteRef = 3CF8B8191E7B905E00FD70DE /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		3CF8B81C1E7B905E00FD70DE /* TimberjackTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = TimberjackTests.xctest;
+			remoteRef = 3CF8B81B1E7B905E00FD70DE /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		A1825E571B99BCA5001C4857 /* Resources */ = {
@@ -152,6 +225,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		3CF8B8201E7B907400FD70DE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Timberjack;
+			targetProxy = 3CF8B81F1E7B907400FD70DE /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		A1825E601B99BCA5001C4857 /* Main.storyboard */ = {
@@ -262,6 +343,7 @@
 		A1825E6C1B99BCA5001C4857 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "Timberjack Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -274,6 +356,7 @@
 		A1825E6D1B99BCA5001C4857 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "Timberjack Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Example/Timberjack Example.xcodeproj/project.pbxproj
+++ b/Example/Timberjack Example.xcodeproj/project.pbxproj
@@ -343,7 +343,6 @@
 		A1825E6C1B99BCA5001C4857 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "Timberjack Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -356,7 +355,6 @@
 		A1825E6D1B99BCA5001C4857 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "Timberjack Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Example/Timberjack Example/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/Timberjack Example/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },

--- a/Tests/TimberjackTests.swift
+++ b/Tests/TimberjackTests.swift
@@ -28,7 +28,7 @@ class TimberjackTests: XCTestCase {
     
     func testPerformanceExample() {
         // This is an example of a performance test case.
-        self.measureBlock() {
+        self.measure() {
             // Put the code you want to measure the time of here.
         }
     }

--- a/Timberjack.xcodeproj/project.pbxproj
+++ b/Timberjack.xcodeproj/project.pbxproj
@@ -162,7 +162,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = "Rocket Town Ltd";
 				TargetAttributes = {
 					A1D2658D1B9999E3000D8735 = {
@@ -240,7 +240,6 @@
 		A1D265A21B9999E3000D8735 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -251,8 +250,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -281,6 +282,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -290,7 +292,6 @@
 		A1D265A31B9999E3000D8735 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -301,8 +302,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -322,6 +325,8 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -333,6 +338,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -344,7 +350,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -352,6 +357,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -362,7 +368,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "co.rockettown.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This pull request reset the ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES flag.

This flag will not cause problem if the user simply uses it during development and removes it from the final App Store bundle. However, when I use xcodebuild on the ci machine to archive my project that includes this framework, a weird `libswiftRemoteMirror.dylib` file will be included into the bundle. And ItunesConnect will reject this bundle. Check [this](http://stackoverflow.com/questions/39480526/what-is-libswiftremotemirror-dylib-and-why-is-it-being-included-in-my-app-bundle) question for reference.

This pull request also restructured how the framework is linked into the demo app. The demo app now can run without any issue in the latest Xcode 8.2+.

This PR won't effect the existing users.

> BTW, if you check other libraries such as Alamofire/SwiftyJSON, they all set ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES to default value. So you can trust this decision.

Let me know if you need more information.